### PR TITLE
Fix issue with POST parameters being separated by "&amp;" instead of "&"

### DIFF
--- a/MoodleRest.php
+++ b/MoodleRest.php
@@ -416,7 +416,7 @@ class MoodleRest
 
         $this->setMethod($method);
 
-        $query_string = is_array($parameters) ? http_build_query($parameters) : '';
+        $query_string = is_array($parameters) ? http_build_query($parameters, '', '&') : '';
 
         $this->setUrl(
             $this->getServerAddress() .


### PR DESCRIPTION
I battled for way too long to get the Moodle enrol_manual_enrol_users service to work. I finally got it working correctly with PHP curl functions, and then had to compare why that one worked and this code didn't. It came down to ampersands being in the POST data.

CURL post data:
```
enrolments%5B0%5D%5Broleid%5D=5&enrolments%5B0%5D%5Buserid%5D=8&enrolments%5B0%5D%5Bcourseid%5D=48&enrolments%5B0%5D%5Btimestart%5D=1693551600&enrolments%5B0%5D%5Btimeend%5D=1697353200
```

MoodleRest post data:
```
enrolments%5B0%5D%5Broleid%5D=5&amp;enrolments%5B0%5D%5Buserid%5D=8&amp;enrolments%5B0%5D%5Bcourseid%5D=48&amp;enrolments%5B0%5D%5Btimestart%5D=1693548000&amp;enrolments%5B0%5D%5Btimeend%5D=1697349600
```